### PR TITLE
Update README to remove missing directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This is where you'll find the notebooks, slides, and spreadsheets for the 2022 e
 ## What's here
 
 - Repo root: notebooks
-- `clean` folder: notebooks without prose or outputs
 - `xl`: Excel spreadsheets
 - `slides`: Jeremy's slide decks
 - `tools`: Ignore (tools for creating this repo)


### PR DESCRIPTION
I think this directory was present in the original repo but it's missing from this export.