### PR TITLE
Fix the gradient accumulation implementation

### DIFF
--- a/10-scaling-up-road-to-the-top-part-3.ipynb
+++ b/10-scaling-up-road-to-the-top-part-3.ipynb
@@ -146,7 +146,7 @@
     "def train(arch, size, item=Resize(480, method='squish'), accum=1, finetune=True, epochs=12):\n",
     "    dls = ImageDataLoaders.from_folder(trn_path, valid_pct=0.2, item_tfms=item,\n",
     "        batch_tfms=aug_transforms(size=size, min_scale=0.75), bs=64//accum)\n",
-    "    cbs = GradientAccumulation(64) if accum else []\n",
+    "    cbs = GradientAccumulation(64) if accum == 1 else GradientAccumulation(64 * accum)\n",
     "    learn = vision_learner(dls, arch, metrics=error_rate, cbs=cbs).to_fp16()\n",
     "    if finetune:\n",
     "        learn.fine_tune(epochs, 0.01)\n",


### PR DESCRIPTION
This is in accordance to [Ahmed Samir's comment on your Road to the Top, Part 3 Kaggle notebook](https://www.kaggle.com/code/jhoward/scaling-up-road-to-the-top-part-3/comments#:~:text=So%20for%20example%20if%20we%20are%20are%20training%20with%20batch%20size%20of%2016%20and%20want%20to%20accumulate%20for%2032%2C%20we%20should%20specify%20an%20argument%20n_acc%3D32.).