### PR TITLE
Exclude test images from training set

### DIFF
--- a/00-is-it-a-bird-creating-a-model-from-your-own-data.ipynb
+++ b/00-is-it-a-bird-creating-a-model-from-your-own-data.ipynb
@@ -262,6 +262,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We don't want to train the model on the test bird and forrest images we downloaded previously.  If the size of a training image is the same size as the test image (after resizing), then remove it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for o in searches:\n",
+    "    resize_image(f'{o}.jpg',max_size=400, dest='test_resized')\n",
+    "    test_size = os.path.getsize(os.path.join('test_resized',f'{o}.jpg'))\n",
+    "    dest = (path/o)\n",
+    "    for f in os.listdir(dest):\n",
+    "      if  os.path.getsize(os.path.join(dest,f)) == test_size:\n",
+    "        print(f'{os.path.join(dest,f)} may be duplicate - removed')\n",
+    "        os.remove(os.path.join(dest,f))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "To train a model, we'll need `DataLoaders`, which is an object that contains a *training set* (the images used to create a model) and a *validation set* (the images used to check the accuracy of a model -- not used during training). In `fastai` we can create that easily using a `DataBlock`, and view sample images from it:"
    ]
   },
@@ -571,6 +594,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The test images (downloaded at the beginning of the lesson) are sometimes re-downloaded and used in the training set. I have suggested a simple fix (discard the training image if it is the same size as the [resized] test image).  There are better ways to do it (and probably more elegant ways to write the fix).

A better implementation may be to pull out a few of the 600 downloaded images, and use these as test images - but I thought this didn't fit in with the flow of the lesson as well.

This is the only lesson I have done - and love it - thanks for all the hard work.

A suggested exercise for students could include - how does the resnet18 model predict without the fine tuning?  (Answer is very poorly!)  