### PR TITLE
Fix clean.py and add back clean folder

### DIFF
--- a/clean/00-is-it-a-bird-creating-a-model-from-your-own-data.ipynb
+++ b/clean/00-is-it-a-bird-creating-a-model-from-your-own-data.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "idx_": 0,
+   "metadata": {},
+   "source": [
+    "## Is it a bird?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#NB: Kaggle requires phone verification to use the internet or a GPU. If you haven't done that yet, the cell below will fail\n",
+    "#    This code is only here to check that your internet is enabled. It doesn't do anything else.\n",
+    "#    Here's a help thread on getting your phone number verified: https://www.kaggle.com/product-feedback/135367\n",
+    "\n",
+    "import socket,warnings\n",
+    "try:\n",
+    "    socket.setdefaulttimeout(1)\n",
+    "    socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(('1.1.1.1', 53))\n",
+    "except socket.error as ex: raise Exception(\"STOP: No internet. Click '>|' in top right and set 'Internet' switch to on\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# It's a good idea to ensure you're running the latest version of any libraries you need.\n",
+    "# `!pip install -Uqq <libraries>` upgrades to the latest version of <libraries>\n",
+    "# NB: You can safely ignore any warnings or errors pip spits out about running as root or incompatibilities\n",
+    "import os\n",
+    "iskaggle = os.environ.get('KAGGLE_KERNEL_RUN_TYPE', '')\n",
+    "\n",
+    "if iskaggle:\n",
+    "    !pip install -Uqq fastai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 6,
+   "metadata": {},
+   "source": [
+    "## Step 1: Download images of birds and non-birds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Skip this cell if you already have duckduckgo_search installed\n",
+    "!pip install -Uqq duckduckgo_search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from duckduckgo_search import ddg_images\n",
+    "from fastcore.all import *\n",
+    "\n",
+    "def search_images(term, max_images=200): return L(ddg_images(term, max_results=max_images)).itemgot('image')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = search_images('bird photos', max_images=1)\n",
+    "urls[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastdownload import download_url\n",
+    "dest = 'bird.jpg'\n",
+    "download_url(urls[0], dest, show_progress=False)\n",
+    "\n",
+    "from fastai.vision.all import *\n",
+    "im = Image.open(dest)\n",
+    "im.to_thumb(256,256)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "download_url(search_images('forest photos', max_images=1)[0], 'forest.jpg', show_progress=False)\n",
+    "Image.open('forest.jpg').to_thumb(256,256)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "searches = 'forest','bird'\n",
+    "path = Path('bird_or_not')\n",
+    "from time import sleep\n",
+    "\n",
+    "for o in searches:\n",
+    "    dest = (path/o)\n",
+    "    dest.mkdir(exist_ok=True, parents=True)\n",
+    "    download_images(dest, urls=search_images(f'{o} photo'))\n",
+    "    sleep(10)  # Pause between searches to avoid over-loading server\n",
+    "    download_images(dest, urls=search_images(f'{o} sun photo'))\n",
+    "    sleep(10)\n",
+    "    download_images(dest, urls=search_images(f'{o} shade photo'))\n",
+    "    sleep(10)\n",
+    "    resize_images(path/o, max_size=400, dest=path/o)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 17,
+   "metadata": {},
+   "source": [
+    "## Step 2: Train our model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "failed = verify_images(get_image_files(path))\n",
+    "failed.map(Path.unlink)\n",
+    "len(failed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dls = DataBlock(\n",
+    "    blocks=(ImageBlock, CategoryBlock), \n",
+    "    get_items=get_image_files, \n",
+    "    splitter=RandomSplitter(valid_pct=0.2, seed=42),\n",
+    "    get_y=parent_label,\n",
+    "    item_tfms=[Resize(192, method='squish')]\n",
+    ").dataloaders(path)\n",
+    "\n",
+    "dls.show_batch(max_n=6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = vision_learner(dls, resnet18, metrics=error_rate)\n",
+    "learn.fine_tune(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 26,
+   "metadata": {},
+   "source": [
+    "## Step 3: Use our model (and build your own!)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_bird,_,probs = learn.predict(PILImage.create('bird.jpg'))\n",
+    "print(f\"This is a: {is_bird}.\")\n",
+    "print(f\"Probability it's a bird: {probs[0]:.4f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4,
+ "path_": "00-is-it-a-bird-creating-a-model-from-your-own-data.ipynb"
+}

--- a/clean/01-jupyter-notebook-101.ipynb
+++ b/clean/01-jupyter-notebook-101.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "idx_": 0,
+   "metadata": {},
+   "source": [
+    "## Introduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "1+1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 4,
+   "metadata": {},
+   "source": [
+    "## Writing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "3/2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 9,
+   "metadata": {},
+   "source": [
+    "## Modes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 11,
+   "metadata": {},
+   "source": [
+    "## Other Important Considerations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pwd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 15,
+   "metadata": {},
+   "source": [
+    "## Markdown Formatting\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 16,
+   "metadata": {},
+   "source": [
+    "### Images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 20,
+   "metadata": {},
+   "source": [
+    "### Italics, Bold, Strikethrough, Inline, Blockquotes and Links"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 22,
+   "metadata": {},
+   "source": [
+    "### Headings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 24,
+   "metadata": {},
+   "source": [
+    "### Lists"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 26,
+   "metadata": {},
+   "source": [
+    "## Code Capabilities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = 1\n",
+    "b = a + 1\n",
+    "c = b + a + 1\n",
+    "d = c + b + a + 1\n",
+    "a, b, c ,d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.plot([a,b,c,d])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 30,
+   "metadata": {},
+   "source": [
+    "## Running Jupyter Locally"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 32,
+   "metadata": {},
+   "source": [
+    "## Shortcuts and Tricks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 34,
+   "metadata": {},
+   "source": [
+    "### Command Mode Shortcuts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 36,
+   "metadata": {},
+   "source": [
+    "### Cell Tricks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "?print"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 39,
+   "metadata": {},
+   "source": [
+    "### Line Magics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%timeit [i+1 for i in range(1000)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 43,
+   "metadata": {},
+   "source": [
+    "## Thanks for reading!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4,
+ "path_": "01-jupyter-notebook-101.ipynb"
+}

--- a/clean/02-saving-a-basic-fastai-model.ipynb
+++ b/clean/02-saving-a-basic-fastai-model.ipynb
@@ -1,0 +1,97 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "idx_": 0,
+   "metadata": {},
+   "source": [
+    "## Saving a Cats v Dogs Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure we've got the latest version of fastai:\n",
+    "!pip install -Uqq fastai"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.vision.all import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = untar_data(URLs.PETS)/'images'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def is_cat(x): return x[0].isupper() "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dls = ImageDataLoaders.from_name_func('.',\n",
+    "    get_image_files(path), valid_pct=0.2, seed=42,\n",
+    "    label_func=is_cat,\n",
+    "    item_tfms=Resize(192))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = vision_learner(dls, resnet18, metrics=error_rate)\n",
+    "learn.fine_tune(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.export('model.pkl')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4,
+ "path_": "02-saving-a-basic-fastai-model.ipynb"
+}

--- a/clean/03-which-image-models-are-best.ipynb
+++ b/clean/03-which-image-models-are-best.ipynb
@@ -1,0 +1,211 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "idx_": 1,
+   "metadata": {},
+   "source": [
+    "## timm\n",
+    "\n",
+    "[PyTorch Image Models](https://timm.fast.ai/) (timm) is a wonderful library by Ross Wightman which provides state-of-the-art pre-trained computer vision models. It's like Huggingface Transformers, but for computer vision instead of NLP (and it's not restricted to transformers-based models)!\n",
+    "\n",
+    "Ross has been kind enough to help me understand how to best take advantage of this library by identifying the top models. I'm going to share here so of what I've learned from him, plus some additional ideas."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 2,
+   "metadata": {},
+   "source": [
+    "## The data\n",
+    "\n",
+    "Ross regularly benchmarks new models as they are added to timm, and puts the results in a CSV in the project's GitHub repo. To analyse the data, we'll first clone the repo:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! git clone --depth 1 https://github.com/rwightman/pytorch-image-models.git\n",
+    "%cd pytorch-image-models/results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "df_results = pd.read_csv('results-imagenet.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_data(part, col):\n",
+    "    df = pd.read_csv(f'benchmark-{part}-amp-nhwc-pt111-cu113-rtx3090.csv').merge(df_results, on='model')\n",
+    "    df['secs'] = 1. / df[col]\n",
+    "    df['family'] = df.model.str.extract('^([a-z]+?(?:v2)?)(?:\\d|_|$)')\n",
+    "    df = df[~df.model.str.endswith('gn')]\n",
+    "    df.loc[df.model.str.contains('in22'),'family'] = df.loc[df.model.str.contains('in22'),'family'] + '_in22'\n",
+    "    df.loc[df.model.str.contains('resnet.*d'),'family'] = df.loc[df.model.str.contains('resnet.*d'),'family'] + 'd'\n",
+    "    return df[df.family.str.contains('^re[sg]netd?|beit|convnext|levit|efficient|vit|vgg')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = get_data('infer', 'infer_samples_per_sec')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 9,
+   "metadata": {},
+   "source": [
+    "## Inference results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.express as px\n",
+    "w,h = 1000,800\n",
+    "\n",
+    "def show_all(df, title, size):\n",
+    "    return px.scatter(df, width=w, height=h, size=df[size]**2, title=title,\n",
+    "        x='secs',  y='top1', log_x=True, color='family', hover_name='model', hover_data=[size])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_all(df, 'Inference', 'infer_img_size')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subs = 'levit|resnetd?|regnetx|vgg|convnext.*|efficientnetv2|beit'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_subs(df, title, size):\n",
+    "    df_subs = df[df.family.str.fullmatch(subs)]\n",
+    "    return px.scatter(df_subs, width=w, height=h, size=df_subs[size]**2, title=title,\n",
+    "        trendline=\"ols\", trendline_options={'log_x':True},\n",
+    "        x='secs',  y='top1', log_x=True, color='family', hover_name='model', hover_data=[size])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_subs(df, 'Inference', 'infer_img_size')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "px.scatter(df, width=w, height=h,\n",
+    "    x='param_count_x',  y='secs', log_x=True, log_y=True, color='infer_img_size',\n",
+    "    hover_name='model', hover_data=['infer_samples_per_sec', 'family']\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 20,
+   "metadata": {},
+   "source": [
+    "## Training results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tdf = get_data('train', 'train_samples_per_sec')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_all(tdf, 'Training', 'train_img_size')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_subs(tdf, 'Training', 'train_img_size')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4,
+ "path_": "03-which-image-models-are-best.ipynb"
+}

--- a/clean/04-how-does-a-neural-net-really-work.ipynb
+++ b/clean/04-how-does-a-neural-net-really-work.ipynb
@@ -1,0 +1,360 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "idx_": 1,
+   "metadata": {},
+   "source": [
+    "## Fitting a function with *gradient descent*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import interact\n",
+    "from fastai.basics import *\n",
+    "\n",
+    "plt.rc('figure', dpi=90)\n",
+    "\n",
+    "def plot_function(f, title=None, min=-2.1, max=2.1, color='r', ylim=None):\n",
+    "    x = torch.linspace(min,max, 100)[:,None]\n",
+    "    if ylim: plt.ylim(ylim)\n",
+    "    plt.plot(x, f(x), color)\n",
+    "    if title is not None: plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def f(x): return 3*x**2 + 2*x + 1\n",
+    "\n",
+    "plot_function(f, \"$3x^2 + 2x + 1$\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def quad(a, b, c, x): return a*x**2 + b*x + c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mk_quad(a,b,c): return partial(quad, a,b,c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f2 = mk_quad(3,2,1)\n",
+    "plot_function(f2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def noise(x, scale): return np.random.normal(scale=scale, size=x.shape)\n",
+    "def add_noise(x, mult, add): return x * (1+noise(x,mult)) + noise(x,add)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(42)\n",
+    "\n",
+    "x = torch.linspace(-2, 2, steps=20)[:,None]\n",
+    "y = add_noise(f(x), 0.15, 1.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x[:5],y[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.scatter(x,y);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@interact(a=1.1, b=1.1, c=1.1)\n",
+    "def plot_quad(a, b, c):\n",
+    "    plt.scatter(x,y)\n",
+    "    plot_function(mk_quad(a,b,c), ylim=(-3,13))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mae(preds, acts): return (torch.abs(preds-acts)).mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@interact(a=1.1, b=1.1, c=1.1)\n",
+    "def plot_quad(a, b, c):\n",
+    "    f = mk_quad(a,b,c)\n",
+    "    plt.scatter(x,y)\n",
+    "    loss = mae(f(x), y)\n",
+    "    plot_function(f, ylim=(-3,12), title=f\"MAE: {loss:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 28,
+   "metadata": {},
+   "source": [
+    "## Automating gradient descent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def quad_mae(params):\n",
+    "    f = mk_quad(*params)\n",
+    "    return mae(f(x), y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quad_mae([1.1, 1.1, 1.1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "abc = torch.tensor([1.1,1.1,1.1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "abc.requires_grad_()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss = quad_mae(abc)\n",
+    "loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss.backward()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "abc.grad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():\n",
+    "    abc -= abc.grad*0.01\n",
+    "    loss = quad_mae(abc)\n",
+    "    \n",
+    "print(f'loss={loss:.2f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(10):\n",
+    "    loss = quad_mae(abc)\n",
+    "    loss.backward()\n",
+    "    with torch.no_grad(): abc -= abc.grad*0.01\n",
+    "    print(f'step={i}; loss={loss:.2f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 48,
+   "metadata": {},
+   "source": [
+    "## How a neural network approximates any given function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 50,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rectified_linear(m,b,x):\n",
+    "    y = m*x+b\n",
+    "    return torch.clip(y, 0.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 52,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_function(partial(rectified_linear, 1,1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch.nn.functional as F\n",
+    "def rectified_linear2(m,b,x): return F.relu(m*x+b)\n",
+    "plot_function(partial(rectified_linear2, 1,1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 56,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@interact(m=1.5, b=1.5)\n",
+    "def plot_relu(m, b):\n",
+    "    plot_function(partial(rectified_linear, m,b), ylim=(-1,4))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def double_relu(m1,b1,m2,b2,x):\n",
+    "    return rectified_linear(m1,b1,x) + rectified_linear(m2,b2,x)\n",
+    "\n",
+    "@interact(m1=-1.5, b1=-1.5, m2=1.5, b2=1.5)\n",
+    "def plot_double_relu(m1, b1, m2, b2):\n",
+    "    plot_function(partial(double_relu, m1,b1,m2,b2), ylim=(-1,6))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 60,
+   "metadata": {},
+   "source": [
+    "## How to recognise an owl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 65,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4,
+ "path_": "04-how-does-a-neural-net-really-work.ipynb"
+}

--- a/clean/05-linear-model-and-neural-net-from-scratch.ipynb
+++ b/clean/05-linear-model-and-neural-net-from-scratch.ipynb
@@ -1,0 +1,955 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "idx_": 0,
+   "metadata": {},
+   "source": [
+    "## Introduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "iskaggle = os.environ.get('KAGGLE_KERNEL_RUN_TYPE', '')\n",
+    "if iskaggle: path = Path('../input/titanic')\n",
+    "else:\n",
+    "    path = Path('titanic')\n",
+    "    if not path.exists():\n",
+    "        import zipfile,kaggle\n",
+    "        kaggle.api.competition_download_cli(str(path))\n",
+    "        zipfile.ZipFile(f'{path}.zip').extractall(path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch, numpy as np, pandas as pd\n",
+    "np.set_printoptions(linewidth=140)\n",
+    "torch.set_printoptions(linewidth=140, sci_mode=False, edgeitems=7)\n",
+    "pd.set_option('display.width', 140)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 5,
+   "metadata": {},
+   "source": [
+    "## Cleaning the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(path/'train.csv')\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.isna().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "modes = df.mode().iloc[0]\n",
+    "modes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.fillna(modes, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.isna().sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "df.describe(include=(np.number))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['Fare'].hist();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['LogFare'] = np.log(df['Fare']+1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['LogFare'].hist();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pclasses = sorted(df.Pclass.unique())\n",
+    "pclasses"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.describe(include=[object])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.get_dummies(df, columns=[\"Sex\",\"Pclass\",\"Embarked\"])\n",
+    "df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "added_cols = ['Sex_male', 'Sex_female', 'Pclass_1', 'Pclass_2', 'Pclass_3', 'Embarked_C', 'Embarked_Q', 'Embarked_S']\n",
+    "df[added_cols].head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch import tensor\n",
+    "\n",
+    "t_dep = tensor(df.Survived)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indep_cols = ['Age', 'SibSp', 'Parch', 'LogFare'] + added_cols\n",
+    "\n",
+    "t_indep = tensor(df[indep_cols].values, dtype=torch.float)\n",
+    "t_indep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t_indep.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 38,
+   "metadata": {},
+   "source": [
+    "## Setting up a linear model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.manual_seed(442)\n",
+    "\n",
+    "n_coeff = t_indep.shape[1]\n",
+    "coeffs = torch.rand(n_coeff)-0.5\n",
+    "coeffs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t_indep*coeffs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vals,indices = t_indep.max(dim=0)\n",
+    "t_indep = t_indep / vals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t_indep*coeffs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds = (t_indep*coeffs).sum(axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 50,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 52,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss = torch.abs(preds-t_dep).mean()\n",
+    "loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calc_preds(coeffs, indeps): return (indeps*coeffs).sum(axis=1)\n",
+    "def calc_loss(coeffs, indeps, deps): return torch.abs(calc_preds(coeffs, indeps)-deps).mean()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 55,
+   "metadata": {},
+   "source": [
+    "## Doing a gradient descent step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 57,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coeffs.requires_grad_()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 59,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss = calc_loss(coeffs, t_indep, t_dep)\n",
+    "loss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 61,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss.backward()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 63,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coeffs.grad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 65,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss = calc_loss(coeffs, t_indep, t_dep)\n",
+    "loss.backward()\n",
+    "coeffs.grad"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 67,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss = calc_loss(coeffs, t_indep, t_dep)\n",
+    "loss.backward()\n",
+    "with torch.no_grad():\n",
+    "    coeffs.sub_(coeffs.grad * 0.1)\n",
+    "    coeffs.grad.zero_()\n",
+    "    print(calc_loss(coeffs, t_indep, t_dep))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 69,
+   "metadata": {},
+   "source": [
+    "## Training the linear model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 71,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.data.transforms import RandomSplitter\n",
+    "trn_split,val_split=RandomSplitter(seed=42)(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 73,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trn_indep,val_indep = t_indep[trn_split],t_indep[val_split]\n",
+    "trn_dep,val_dep = t_dep[trn_split],t_dep[val_split]\n",
+    "len(trn_indep),len(val_indep)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 75,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def update_coeffs(coeffs, lr):\n",
+    "    coeffs.sub_(coeffs.grad * lr)\n",
+    "    coeffs.grad.zero_()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 76,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def one_epoch(coeffs, lr):\n",
+    "    loss = calc_loss(coeffs, trn_indep, trn_dep)\n",
+    "    loss.backward()\n",
+    "    with torch.no_grad(): update_coeffs(coeffs, lr)\n",
+    "    print(f\"{loss:.3f}\", end=\"; \")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 77,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def init_coeffs(): return (torch.rand(n_coeff)-0.5).requires_grad_()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 79,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_model(epochs=30, lr=0.01):\n",
+    "    torch.manual_seed(442)\n",
+    "    coeffs = init_coeffs()\n",
+    "    for i in range(epochs): one_epoch(coeffs, lr=lr)\n",
+    "    return coeffs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 81,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coeffs = train_model(18, lr=0.2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 83,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_coeffs(): return dict(zip(indep_cols, coeffs.requires_grad_(False)))\n",
+    "show_coeffs()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 84,
+   "metadata": {},
+   "source": [
+    "## Measuring accuracy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 86,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds = calc_preds(coeffs, val_indep)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 88,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = val_dep.bool()==(preds>0.5)\n",
+    "results[:16]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 90,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results.float().mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 92,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def acc(coeffs): return (val_dep.bool()==(calc_preds(coeffs, val_indep)>0.5)).float().mean()\n",
+    "acc(coeffs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 93,
+   "metadata": {},
+   "source": [
+    "## Using sigmoid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 95,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds[:28]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 97,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sympy\n",
+    "sympy.plot(\"1/(1+exp(-x))\", xlim=(-5,5));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 99,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calc_preds(coeffs, indeps): return torch.sigmoid((indeps*coeffs).sum(axis=1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 101,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coeffs = train_model(lr=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 103,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acc(coeffs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 105,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_coeffs()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 107,
+   "metadata": {},
+   "source": [
+    "## Submitting to Kaggle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 109,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst_df = pd.read_csv(path/'test.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 111,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst_df['Fare'] = tst_df.Fare.fillna(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 113,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst_df.fillna(modes, inplace=True)\n",
+    "tst_df['LogFare'] = np.log(tst_df['Fare']+1)\n",
+    "tst_df = pd.get_dummies(tst_df, columns=[\"Sex\",\"Pclass\",\"Embarked\"])\n",
+    "\n",
+    "tst_indep = tensor(tst_df[indep_cols].values, dtype=torch.float)\n",
+    "tst_indep = tst_indep / vals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 115,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst_df['Survived'] = (calc_preds(tst_indep, coeffs)>0.5).int()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 117,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sub_df = tst_df[['PassengerId','Survived']]\n",
+    "sub_df.to_csv('sub.csv', index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 119,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!head sub.csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 121,
+   "metadata": {},
+   "source": [
+    "## Using matrix product"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 123,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(val_indep*coeffs).sum(axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 125,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "val_indep@coeffs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 127,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calc_preds(coeffs, indeps): return torch.sigmoid(indeps@coeffs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 129,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def init_coeffs(): return (torch.rand(n_coeff, 1)*0.1).requires_grad_()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 131,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trn_dep = trn_dep[:,None]\n",
+    "val_dep = val_dep[:,None]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 133,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coeffs = train_model(lr=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 135,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acc(coeffs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 136,
+   "metadata": {},
+   "source": [
+    "## A neural network"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 138,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def init_coeffs(n_hidden=20):\n",
+    "    layer1 = (torch.rand(n_coeff, n_hidden)-0.5)/n_hidden\n",
+    "    layer2 = torch.rand(n_hidden, 1)-0.3\n",
+    "    const = torch.rand(1)[0]\n",
+    "    return layer1.requires_grad_(),layer2.requires_grad_(),const.requires_grad_()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 140,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch.nn.functional as F\n",
+    "\n",
+    "def calc_preds(coeffs, indeps):\n",
+    "    l1,l2,const = coeffs\n",
+    "    res = F.relu(indeps@l1)\n",
+    "    res = res@l2 + const\n",
+    "    return torch.sigmoid(res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 142,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def update_coeffs(coeffs, lr):\n",
+    "    for layer in coeffs:\n",
+    "        layer.sub_(layer.grad * lr)\n",
+    "        layer.grad.zero_()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 144,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coeffs = train_model(lr=1.4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 145,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coeffs = train_model(lr=20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 147,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acc(coeffs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 149,
+   "metadata": {},
+   "source": [
+    "## Deep learning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 151,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def init_coeffs():\n",
+    "    hiddens = [10, 10]  # <-- set this to the size of each hidden layer you want\n",
+    "    sizes = [n_coeff] + hiddens + [1]\n",
+    "    n = len(sizes)\n",
+    "    layers = [(torch.rand(sizes[i], sizes[i+1])-0.3)/sizes[i+1]*4 for i in range(n-1)]\n",
+    "    consts = [(torch.rand(1)[0]-0.5)*0.1 for i in range(n-1)]\n",
+    "    for l in layers+consts: l.requires_grad_()\n",
+    "    return layers,consts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 153,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch.nn.functional as F\n",
+    "\n",
+    "def calc_preds(coeffs, indeps):\n",
+    "    layers,consts = coeffs\n",
+    "    n = len(layers)\n",
+    "    res = indeps\n",
+    "    for i,l in enumerate(layers):\n",
+    "        res = res@l + consts[i]\n",
+    "        if i!=n-1: res = F.relu(res)\n",
+    "    return torch.sigmoid(res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 155,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def update_coeffs(coeffs, lr):\n",
+    "    layers,consts = coeffs\n",
+    "    for layer in layers+consts:\n",
+    "        layer.sub_(layer.grad * lr)\n",
+    "        layer.grad.zero_()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 157,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coeffs = train_model(lr=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 159,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "acc(coeffs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 160,
+   "metadata": {},
+   "source": [
+    "## Final thoughts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 162,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4,
+ "path_": "05-linear-model-and-neural-net-from-scratch.ipynb"
+}

--- a/clean/06-why-you-should-use-a-framework.ipynb
+++ b/clean/06-why-you-should-use-a-framework.ipynb
@@ -1,0 +1,280 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "idx_": 0,
+   "metadata": {},
+   "source": [
+    "## Introduction and set up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import os\n",
+    "\n",
+    "iskaggle = os.environ.get('KAGGLE_KERNEL_RUN_TYPE', '')\n",
+    "if iskaggle:\n",
+    "    path = Path('../input/titanic')\n",
+    "    !pip install -Uqq fastai\n",
+    "else:\n",
+    "    import zipfile,kaggle\n",
+    "    path = Path('titanic')\n",
+    "    kaggle.api.competition_download_cli(str(path))\n",
+    "    zipfile.ZipFile(f'{path}.zip').extractall(path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.tabular.all import *\n",
+    "\n",
+    "pd.options.display.float_format = '{:.2f}'.format\n",
+    "set_seed(42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 5,
+   "metadata": {},
+   "source": [
+    "## Prep the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(path/'train.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add_features(df):\n",
+    "    df['LogFare'] = np.log1p(df['Fare'])\n",
+    "    df['Deck'] = df.Cabin.str[0].map(dict(A=\"ABC\", B=\"ABC\", C=\"ABC\", D=\"DE\", E=\"DE\", F=\"FG\", G=\"FG\"))\n",
+    "    df['Family'] = df.SibSp+df.Parch\n",
+    "    df['Alone'] = df.Family==1\n",
+    "    df['TicketFreq'] = df.groupby('Ticket')['Ticket'].transform('count')\n",
+    "    df['Title'] = df.Name.str.split(', ', expand=True)[1].str.split('.', expand=True)[0]\n",
+    "    df['Title'] = df.Title.map(dict(Mr=\"Mr\",Miss=\"Miss\",Mrs=\"Mrs\",Master=\"Master\")).value_counts(dropna=False)\n",
+    "\n",
+    "add_features(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "splits = RandomSplitter(seed=42)(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dls = TabularPandas(\n",
+    "    df, splits=splits,\n",
+    "    procs = [Categorify, FillMissing, Normalize],\n",
+    "    cat_names=[\"Sex\",\"Pclass\",\"Embarked\",\"Deck\", \"Title\"],\n",
+    "    cont_names=['Age', 'SibSp', 'Parch', 'LogFare', 'Alone', 'TicketFreq', 'Family'],\n",
+    "    y_names=\"Survived\", y_block = CategoryBlock(),\n",
+    ").dataloaders(path=\".\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 15,
+   "metadata": {},
+   "source": [
+    "## Train the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = tabular_learner(dls, metrics=accuracy, layers=[10,10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.lr_find(suggest_funcs=(slide, valley))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.fit(16, lr=0.03)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 23,
+   "metadata": {},
+   "source": [
+    "## Submit to Kaggle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst_df = pd.read_csv(path/'test.csv')\n",
+    "tst_df['Fare'] = tst_df.Fare.fillna(0)\n",
+    "add_features(tst_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst_dl = learn.dls.test_dl(tst_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds,_ = learn.get_preds(dl=tst_dl)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst_df['Survived'] = (preds[:,1]>0.5).int()\n",
+    "sub_df = tst_df[['PassengerId','Survived']]\n",
+    "sub_df.to_csv('sub.csv', index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!head sub.csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 34,
+   "metadata": {},
+   "source": [
+    "## Ensembling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ensemble():\n",
+    "    learn = tabular_learner(dls, metrics=accuracy, layers=[10,10])\n",
+    "    with learn.no_bar(),learn.no_logging(): learn.fit(16, lr=0.03)\n",
+    "    return learn.get_preds(dl=tst_dl)[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learns = [ensemble() for _ in range(5)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ens_preds = torch.stack(learns).mean(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst_df['Survived'] = (ens_preds[:,1]>0.5).int()\n",
+    "sub_df = tst_df[['PassengerId','Survived']]\n",
+    "sub_df.to_csv('ens_sub.csv', index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 44,
+   "metadata": {},
+   "source": [
+    "## Final thoughts"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4,
+ "path_": "06-why-you-should-use-a-framework.ipynb"
+}

--- a/clean/07-how-random-forests-really-work.ipynb
+++ b/clean/07-how-random-forests-really-work.ipynb
@@ -1,0 +1,599 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "idx_": 0,
+   "metadata": {},
+   "source": [
+    "## Introduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.imports import *\n",
+    "np.set_printoptions(linewidth=130)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 3,
+   "metadata": {},
+   "source": [
+    "## Data preprocessing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "iskaggle = os.environ.get('KAGGLE_KERNEL_RUN_TYPE', '')\n",
+    "\n",
+    "if iskaggle: path = Path('../input/titanic')\n",
+    "else:\n",
+    "    import zipfile,kaggle\n",
+    "    path = Path('titanic')\n",
+    "    kaggle.api.competition_download_cli(str(path))\n",
+    "    zipfile.ZipFile(f'{path}.zip').extractall(path)\n",
+    "\n",
+    "df = pd.read_csv(path/'train.csv')\n",
+    "tst_df = pd.read_csv(path/'test.csv')\n",
+    "modes = df.mode().iloc[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def proc_data(df):\n",
+    "    df['Fare'] = df.Fare.fillna(0)\n",
+    "    df.fillna(modes, inplace=True)\n",
+    "    df['LogFare'] = np.log1p(df['Fare'])\n",
+    "    df['Embarked'] = pd.Categorical(df.Embarked)\n",
+    "    df['Sex'] = pd.Categorical(df.Sex)\n",
+    "\n",
+    "proc_data(df)\n",
+    "proc_data(tst_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cats=[\"Sex\",\"Embarked\"]\n",
+    "conts=['Age', 'SibSp', 'Parch', 'LogFare',\"Pclass\"]\n",
+    "dep=\"Survived\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.Sex.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.Sex.cat.codes.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 14,
+   "metadata": {},
+   "source": [
+    "## Binary splits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import seaborn as sns\n",
+    "\n",
+    "fig,axs = plt.subplots(1,2, figsize=(11,5))\n",
+    "sns.barplot(data=df, y=dep, x=\"Sex\", ax=axs[0]).set(title=\"Survival rate\")\n",
+    "sns.countplot(data=df, x=\"Sex\", ax=axs[1]).set(title=\"Histogram\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numpy import random\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "random.seed(42)\n",
+    "trn_df,val_df = train_test_split(df, test_size=0.25)\n",
+    "trn_df[cats] = trn_df[cats].apply(lambda x: x.cat.codes)\n",
+    "val_df[cats] = val_df[cats].apply(lambda x: x.cat.codes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def xs_y(df):\n",
+    "    xs = df[cats+conts].copy()\n",
+    "    return xs,df[dep] if dep in df else None\n",
+    "\n",
+    "trn_xs,trn_y = xs_y(trn_df)\n",
+    "val_xs,val_y = xs_y(val_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds = val_xs.Sex==0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics import mean_absolute_error\n",
+    "mean_absolute_error(val_y, preds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_fare = trn_df[trn_df.LogFare>0]\n",
+    "fig,axs = plt.subplots(1,2, figsize=(11,5))\n",
+    "sns.boxenplot(data=df_fare, x=dep, y=\"LogFare\", ax=axs[0])\n",
+    "sns.kdeplot(data=df_fare, x=\"LogFare\", ax=axs[1]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds = val_xs.LogFare>2.7"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_absolute_error(val_y, preds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _side_score(side, y):\n",
+    "    tot = side.sum()\n",
+    "    if tot<=1: return 0\n",
+    "    return y[side].std()*tot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    \n",
+    "def score(col, y, split):\n",
+    "    lhs = col<=split\n",
+    "    return (_side_score(lhs,y) + _side_score(~lhs,y))/len(y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "score(trn_xs[\"Sex\"], trn_y, 0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "score(trn_xs[\"LogFare\"], trn_y, 2.7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def iscore(nm, split):\n",
+    "    col = trn_xs[nm]\n",
+    "    return score(col, trn_y, split)\n",
+    "\n",
+    "from ipywidgets import interact\n",
+    "interact(nm=conts, split=15.5)(iscore);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interact(nm=cats, split=2)(iscore);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nm = \"Age\"\n",
+    "col = trn_xs[nm]\n",
+    "unq = col.unique()\n",
+    "unq.sort()\n",
+    "unq"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scores = np.array([score(col, trn_y, o) for o in unq if not np.isnan(o)])\n",
+    "unq[scores.argmin()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def min_col(df, nm):\n",
+    "    col,y = df[nm],df[dep]\n",
+    "    unq = col.dropna().unique()\n",
+    "    scores = np.array([score(col, y, o) for o in unq if not np.isnan(o)])\n",
+    "    idx = scores.argmin()\n",
+    "    return unq[idx],scores[idx]\n",
+    "\n",
+    "min_col(trn_df, \"Age\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 50,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cols = cats+conts\n",
+    "{o:min_col(trn_df, o) for o in cols}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 52,
+   "metadata": {},
+   "source": [
+    "## Creating a decision tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cols.remove(\"Sex\")\n",
+    "ismale = trn_df.Sex==1\n",
+    "males,females = trn_df[ismale],trn_df[~ismale]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 56,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "{o:min_col(males, o) for o in cols}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "{o:min_col(females, o) for o in cols}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 60,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.tree import DecisionTreeClassifier, export_graphviz\n",
+    "\n",
+    "m = DecisionTreeClassifier(max_leaf_nodes=4).fit(trn_xs, trn_y);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 62,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import graphviz\n",
+    "\n",
+    "def draw_tree(t, df, size=10, ratio=0.6, precision=2, **kwargs):\n",
+    "    s=export_graphviz(t, out_file=None, feature_names=df.columns, filled=True, rounded=True,\n",
+    "                      special_characters=True, rotate=False, precision=precision, **kwargs)\n",
+    "    return graphviz.Source(re.sub('Tree {', f'Tree {{ size={size}; ratio={ratio}', s))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 63,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "draw_tree(m, trn_xs, size=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 65,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gini(cond):\n",
+    "    act = df.loc[cond, dep]\n",
+    "    return 1 - act.mean()**2 - (1-act).mean()**2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 67,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gini(df.Sex=='female'), gini(df.Sex=='male')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 69,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_absolute_error(val_y, m.predict(val_xs))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 71,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = DecisionTreeClassifier(min_samples_leaf=50)\n",
+    "m.fit(trn_xs, trn_y)\n",
+    "draw_tree(m, trn_xs, size=25)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 72,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_absolute_error(val_y, m.predict(val_xs))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 74,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst_df[cats] = tst_df[cats].apply(lambda x: x.cat.codes)\n",
+    "tst_xs,_ = xs_y(tst_df)\n",
+    "\n",
+    "def subm(preds, suff):\n",
+    "    tst_df['Survived'] = preds\n",
+    "    sub_df = tst_df[['PassengerId','Survived']]\n",
+    "    sub_df.to_csv(f'sub-{suff}.csv', index=False)\n",
+    "\n",
+    "subm(m.predict(tst_xs), 'tree')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 76,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.Embarked.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 78,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.Embarked.cat.codes.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 80,
+   "metadata": {},
+   "source": [
+    "## The random forest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 82,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_tree(prop=0.75):\n",
+    "    n = len(trn_y)\n",
+    "    idxs = random.choice(n, int(n*prop))\n",
+    "    return DecisionTreeClassifier(min_samples_leaf=5).fit(trn_xs.iloc[idxs], trn_y.iloc[idxs])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 84,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trees = [get_tree() for t in range(100)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 86,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_probs = [t.predict(val_xs) for t in trees]\n",
+    "avg_probs = np.stack(all_probs).mean(0)\n",
+    "\n",
+    "mean_absolute_error(val_y, avg_probs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 88,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "\n",
+    "rf = RandomForestClassifier(100, min_samples_leaf=5)\n",
+    "rf.fit(trn_xs, trn_y);\n",
+    "mean_absolute_error(val_y, rf.predict(val_xs))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 90,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subm(rf.predict(tst_xs), 'rf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "idx_": 93,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.DataFrame(dict(cols=trn_xs.columns, imp=m.feature_importances_)).plot('cols', 'imp', 'barh');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "idx_": 95,
+   "metadata": {},
+   "source": [
+    "## Conclusion"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4,
+ "path_": "07-how-random-forests-really-work.ipynb"
+}

--- a/clean/08-first-steps-road-to-the-top-part-1.ipynb
+++ b/clean/08-first-steps-road-to-the-top-part-1.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "732f09f4",
+   "idx_": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# install fastkaggle if not available\n",
+    "try: import fastkaggle\n",
+    "except ModuleNotFoundError:\n",
+    "    !pip install -Uq fastkaggle\n",
+    "\n",
+    "from fastkaggle import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0f21256",
+   "idx_": 3,
+   "metadata": {},
+   "source": [
+    "## Getting set up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70f2d75c",
+   "idx_": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "comp = 'paddy-disease-classification'\n",
+    "\n",
+    "path = setup_comp(comp, install='fastai \"timm>=0.6.2.dev0\"')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "879f9000",
+   "idx_": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c8e2512",
+   "idx_": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastai.vision.all import *\n",
+    "set_seed(42)\n",
+    "\n",
+    "path.ls()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b0c8526",
+   "idx_": 9,
+   "metadata": {},
+   "source": [
+    "## Looking at the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7dc65858",
+   "idx_": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trn_path = path/'train_images'\n",
+    "files = get_image_files(trn_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa37d1e7",
+   "idx_": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img = PILImage.create(files[0])\n",
+    "print(img.size)\n",
+    "img.to_thumb(128)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc65a07f",
+   "idx_": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastcore.parallel import *\n",
+    "\n",
+    "def f(o): return PILImage.create(o).size\n",
+    "sizes = parallel(f, files, n_workers=8)\n",
+    "pd.Series(sizes).value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28089cd4",
+   "idx_": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dls = ImageDataLoaders.from_folder(trn_path, valid_pct=0.2, seed=42,\n",
+    "    item_tfms=Resize(480, method='squish'),\n",
+    "    batch_tfms=aug_transforms(size=128, min_scale=0.75))\n",
+    "\n",
+    "dls.show_batch(max_n=6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1edb043d",
+   "idx_": 18,
+   "metadata": {},
+   "source": [
+    "## Our first model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61cce208",
+   "idx_": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = vision_learner(dls, 'resnet26d', metrics=error_rate, path='.').to_fp16()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b7ca2ac",
+   "idx_": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.lr_find(suggest_funcs=(valley, slide))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b765c1f",
+   "idx_": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.fine_tune(3, 0.01)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ab26601",
+   "idx_": 26,
+   "metadata": {},
+   "source": [
+    "## Submitting to Kaggle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55cd25e5",
+   "idx_": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ss = pd.read_csv(path/'sample_submission.csv')\n",
+    "ss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3c88925",
+   "idx_": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst_files = get_image_files(path/'test_images').sorted()\n",
+    "tst_dl = dls.test_dl(tst_files)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04aa5ace",
+   "idx_": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "probs,_,idxs = learn.get_preds(dl=tst_dl, with_decoded=True)\n",
+    "idxs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6c4b31d",
+   "idx_": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dls.vocab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc5935d2",
+   "idx_": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mapping = dict(enumerate(dls.vocab))\n",
+    "results = pd.Series(idxs.numpy(), name=\"idxs\").map(mapping)\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3f2ec9e",
+   "idx_": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ss['label'] = results\n",
+    "ss.to_csv('subm.csv', index=False)\n",
+    "!head subm.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed52342c",
+   "idx_": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not iskaggle:\n",
+    "    from kaggle import api\n",
+    "    api.competition_submit_cli('subm.csv', 'initial rn26d 128px', comp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e04efcc0",
+   "idx_": 41,
+   "metadata": {},
+   "source": [
+    "## Conclusion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a972c10e",
+   "idx_": 43,
+   "metadata": {},
+   "source": [
+    "## Addendum"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd2148d7",
+   "idx_": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not iskaggle:\n",
+    "    push_notebook('jhoward', 'first-steps-road-to-the-top-part-1',\n",
+    "                  title='First Steps: Road to the Top, Part 1',\n",
+    "                  file='first-steps-road-to-the-top-part-1.ipynb',\n",
+    "                  competition=comp, private=False, gpu=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ca975e7",
+   "idx_": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "path_": "08-first-steps-road-to-the-top-part-1.ipynb"
+}

--- a/clean/09-small-models-road-to-the-top-part-2.ipynb
+++ b/clean/09-small-models-road-to-the-top-part-2.ipynb
@@ -1,0 +1,412 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75be51b1",
+   "idx_": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# install fastkaggle if not available\n",
+    "try: import fastkaggle\n",
+    "except ModuleNotFoundError:\n",
+    "    !pip install -Uq fastkaggle\n",
+    "\n",
+    "from fastkaggle import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad80d057",
+   "idx_": 2,
+   "metadata": {},
+   "source": [
+    "## Going faster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5557a76e",
+   "idx_": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "comp = 'paddy-disease-classification'\n",
+    "path = setup_comp(comp, install='fastai \"timm>=0.6.2.dev0\"')\n",
+    "from fastai.vision.all import *\n",
+    "set_seed(42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3d9cab9",
+   "idx_": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trn_path = Path('sml')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd776ce8",
+   "idx_": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resize_images(path/'train_images', dest=trn_path, max_size=256, recurse=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e64f802b",
+   "idx_": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dls = ImageDataLoaders.from_folder(trn_path, valid_pct=0.2, seed=42,\n",
+    "    item_tfms=Resize((256,192)))\n",
+    "\n",
+    "dls.show_batch(max_n=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b4e9915",
+   "idx_": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train(arch, item, batch, epochs=5):\n",
+    "    dls = ImageDataLoaders.from_folder(trn_path, seed=42, valid_pct=0.2, item_tfms=item, batch_tfms=batch)\n",
+    "    learn = vision_learner(dls, arch, metrics=error_rate).to_fp16()\n",
+    "    learn.fine_tune(epochs, 0.01)\n",
+    "    return learn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a628c8e",
+   "idx_": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = train('resnet26d', item=Resize(192),\n",
+    "              batch=aug_transforms(size=128, min_scale=0.75))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "538ba512",
+   "idx_": 15,
+   "metadata": {},
+   "source": [
+    "## A ConvNeXt model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9978175",
+   "idx_": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arch = 'convnext_small_in22k'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3caa4f06",
+   "idx_": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = train(arch, item=Resize(192, method='squish'),\n",
+    "              batch=aug_transforms(size=128, min_scale=0.75))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d640fecf",
+   "idx_": 20,
+   "metadata": {},
+   "source": [
+    "## Preprocessing experiments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c9d172c",
+   "idx_": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = train(arch, item=Resize(192),\n",
+    "              batch=aug_transforms(size=128, min_scale=0.75))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9478a751",
+   "idx_": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dls = ImageDataLoaders.from_folder(trn_path, valid_pct=0.2, seed=42,\n",
+    "    item_tfms=Resize(192, method=ResizeMethod.Pad, pad_mode=PadMode.Zeros))\n",
+    "dls.show_batch(max_n=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11388ce4",
+   "idx_": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = train(arch, item=Resize((256,192), method=ResizeMethod.Pad, pad_mode=PadMode.Zeros),\n",
+    "      batch=aug_transforms(size=(171,128), min_scale=0.75))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f68f0a3",
+   "idx_": 27,
+   "metadata": {},
+   "source": [
+    "## Test time augmentation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6e9c5cb",
+   "idx_": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "valid = learn.dls.valid\n",
+    "preds,targs = learn.get_preds(dl=valid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7cf8953",
+   "idx_": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "error_rate(preds, targs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83edb04c",
+   "idx_": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn.dls.train.show_batch(max_n=6, unique=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a0ffc75",
+   "idx_": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tta_preds,_ = learn.tta(dl=valid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cf6a100",
+   "idx_": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "error_rate(tta_preds, targs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d549e92",
+   "idx_": 38,
+   "metadata": {},
+   "source": [
+    "## Scaling up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "060538b8",
+   "idx_": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trn_path = path/'train_images'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f5d5c56",
+   "idx_": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "learn = train(arch, epochs=12,\n",
+    "              item=Resize((480, 360), method=ResizeMethod.Pad, pad_mode=PadMode.Zeros),\n",
+    "              batch=aug_transforms(size=(256,192), min_scale=0.75))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2e21a6f",
+   "idx_": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tta_preds,targs = learn.tta(dl=learn.dls.valid)\n",
+    "error_rate(tta_preds, targs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "437e77bc",
+   "idx_": 45,
+   "metadata": {},
+   "source": [
+    "## Submission"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b28e5ab",
+   "idx_": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tst_files = get_image_files(path/'test_images').sorted()\n",
+    "tst_dl = learn.dls.test_dl(tst_files)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d29d42e",
+   "idx_": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds,_ = learn.tta(dl=tst_dl)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ec6f17d",
+   "idx_": 51,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "idxs = preds.argmax(dim=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f458777b",
+   "idx_": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vocab = np.array(learn.dls.vocab)\n",
+    "results = pd.Series(vocab[idxs], name=\"idxs\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1e306be",
+   "idx_": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ss = pd.read_csv(path/'sample_submission.csv')\n",
+    "ss['label'] = results\n",
+    "ss.to_csv('subm.csv', index=False)\n",
+    "!head subm.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34de5bc9",
+   "idx_": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not iskaggle:\n",
+    "    from kaggle import api\n",
+    "    api.competition_submit_cli('subm.csv', 'convnext small 256x192 12 epochs tta', comp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcb49d9c",
+   "idx_": 57,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is what I use to push my notebook from my home PC to Kaggle\n",
+    "\n",
+    "if not iskaggle:\n",
+    "    push_notebook('jhoward', 'small-models-road-to-the-top-part-2',\n",
+    "                  title='Small models: Road to the Top, Part 2',\n",
+    "                  file='small-models-road-to-the-top-part-2.ipynb',\n",
+    "                  competition=comp, private=True, gpu=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9ed54c9",
+   "idx_": 58,
+   "metadata": {},
+   "source": [
+    "## Conclusion"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "path_": "09-small-models-road-to-the-top-part-2.ipynb"
+}

--- a/clean/10-scaling-up-road-to-the-top-part-3.ipynb
+++ b/clean/10-scaling-up-road-to-the-top-part-3.ipynb
@@ -1,0 +1,434 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51f17fe5",
+   "idx_": 0,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# install fastkaggle if not available\n",
+    "try: import fastkaggle\n",
+    "except ModuleNotFoundError:\n",
+    "    !pip install -Uq fastkaggle\n",
+    "\n",
+    "from fastkaggle import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75eadfab",
+   "idx_": 2,
+   "metadata": {},
+   "source": [
+    "## Memory and gradient accumulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c8e2512",
+   "idx_": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "comp = 'paddy-disease-classification'\n",
+    "path = setup_comp(comp, install='fastai \"timm>=0.6.2.dev0\"')\n",
+    "from fastai.vision.all import *\n",
+    "set_seed(42)\n",
+    "\n",
+    "tst_files = get_image_files(path/'test_images').sorted()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16c330ca",
+   "idx_": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(path/'train.csv')\n",
+    "df.label.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2231c84a",
+   "idx_": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trn_path = path/'train_images'/'bacterial_panicle_blight'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73c61814",
+   "idx_": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train(arch, size, item=Resize(480, method='squish'), accum=1, finetune=True, epochs=12):\n",
+    "    dls = ImageDataLoaders.from_folder(trn_path, valid_pct=0.2, item_tfms=item,\n",
+    "        batch_tfms=aug_transforms(size=size, min_scale=0.75), bs=64//accum)\n",
+    "    cbs = GradientAccumulation(64) if accum else []\n",
+    "    learn = vision_learner(dls, arch, metrics=error_rate, cbs=cbs).to_fp16()\n",
+    "    if finetune:\n",
+    "        learn.fine_tune(epochs, 0.01)\n",
+    "        return learn.tta(dl=dls.test_dl(tst_files))\n",
+    "    else:\n",
+    "        learn.unfreeze()\n",
+    "        learn.fit_one_cycle(epochs, 0.01)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e656c0d",
+   "idx_": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train('convnext_small_in22k', 128, epochs=1, accum=1, finetune=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d6b0e03",
+   "idx_": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gc\n",
+    "def report_gpu():\n",
+    "    print(torch.cuda.list_gpu_processes())\n",
+    "    gc.collect()\n",
+    "    torch.cuda.empty_cache()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c0b2441",
+   "idx_": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_gpu()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0a5f501",
+   "idx_": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train('convnext_small_in22k', 128, epochs=1, accum=2, finetune=False)\n",
+    "report_gpu()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5afc86bd",
+   "idx_": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train('convnext_small_in22k', 128, epochs=1, accum=4, finetune=False)\n",
+    "report_gpu()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7376e138",
+   "idx_": 21,
+   "metadata": {},
+   "source": [
+    "## Checking memory use"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7bf9f72",
+   "idx_": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train('convnext_large_in22k', 224, epochs=1, accum=2, finetune=False)\n",
+    "report_gpu()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adf6d642",
+   "idx_": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train('convnext_large_in22k', (320,240), epochs=1, accum=2, finetune=False)\n",
+    "report_gpu()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dbb9f38c",
+   "idx_": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train('vit_large_patch16_224', 224, epochs=1, accum=2, finetune=False)\n",
+    "report_gpu()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc92938b",
+   "idx_": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train('swinv2_large_window12_192_22k', 192, epochs=1, accum=2, finetune=False)\n",
+    "report_gpu()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e8cefbb",
+   "idx_": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train('swin_large_patch4_window7_224', 224, epochs=1, accum=2, finetune=False)\n",
+    "report_gpu()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5a55b7f",
+   "idx_": 30,
+   "metadata": {},
+   "source": [
+    "## Running the models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c58260ff",
+   "idx_": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = 640,480"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8dc102b",
+   "idx_": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models = {\n",
+    "    'convnext_large_in22k': {\n",
+    "        (Resize(res), 224),\n",
+    "        (Resize(res), (320,224)),\n",
+    "    }, 'vit_large_patch16_224': {\n",
+    "        (Resize(480, method='squish'), 224),\n",
+    "        (Resize(res), 224),\n",
+    "    }, 'swinv2_large_window12_192_22k': {\n",
+    "        (Resize(480, method='squish'), 192),\n",
+    "        (Resize(res), 192),\n",
+    "    }, 'swin_large_patch4_window7_224': {\n",
+    "        (Resize(480, method='squish'), 224),\n",
+    "        (Resize(res), 224),\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b418ece4",
+   "idx_": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trn_path = path/'train_images'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91ed5157",
+   "idx_": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tta_res = []\n",
+    "\n",
+    "for arch,details in models.items():\n",
+    "    for item,size in details:\n",
+    "        print('---',arch)\n",
+    "        print(size)\n",
+    "        print(item.name)\n",
+    "        tta_res.append(train(arch, size, item=item, accum=2)) #, epochs=1))\n",
+    "        gc.collect()\n",
+    "        torch.cuda.empty_cache()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3bd2d9b",
+   "idx_": 38,
+   "metadata": {},
+   "source": [
+    "## Ensembling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b370e7e3",
+   "idx_": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_pickle('tta_res.pkl', tta_res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8de40a4d",
+   "idx_": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tta_prs = first(zip(*tta_res))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3093b5a6",
+   "idx_": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tta_prs += tta_prs[2:4]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64d79d4c",
+   "idx_": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "avg_pr = torch.stack(tta_prs).mean(0)\n",
+    "avg_pr.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d71eab6",
+   "idx_": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dls = ImageDataLoaders.from_folder(trn_path, valid_pct=0.2, item_tfms=Resize(480, method='squish'),\n",
+    "    batch_tfms=aug_transforms(size=224, min_scale=0.75))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d8bad75",
+   "idx_": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "idxs = avg_pr.argmax(dim=1)\n",
+    "vocab = np.array(dls.vocab)\n",
+    "ss = pd.read_csv(path/'sample_submission.csv')\n",
+    "ss['label'] = vocab[idxs]\n",
+    "ss.to_csv('subm.csv', index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e244be1",
+   "idx_": 51,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not iskaggle:\n",
+    "    from kaggle import api\n",
+    "    api.competition_submit_cli('subm.csv', 'part 3 v2', comp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9ed54c9",
+   "idx_": 54,
+   "metadata": {},
+   "source": [
+    "## Conclusion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5b966c6",
+   "idx_": 56,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is what I use to push my notebook from my home PC to Kaggle\n",
+    "\n",
+    "if not iskaggle:\n",
+    "    push_notebook('jhoward', 'scaling-up-road-to-the-top-part-3',\n",
+    "                  title='Scaling Up: Road to the Top, Part 3',\n",
+    "                  file='10-scaling-up-road-to-the-top-part-3.ipynb',\n",
+    "                  competition=comp, private=False, gpu=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef58b48e",
+   "idx_": 57,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "path_": "10-scaling-up-road-to-the-top-part-3.ipynb"
+}

--- a/tools/clean.py
+++ b/tools/clean.py
@@ -4,6 +4,7 @@ import nbformat
 from nbdev.export import *
 from nbdev.clean import *
 from fastcore.all import *
+from execnb.nbio import *
 
 _re_header = re.compile(r'^#+\s+\S+')
 _re_clean  = re.compile(r'^\s*#\s*clean\s*')


### PR DESCRIPTION
This PR fixes the `clean.py` script by adding `from execnb.nbio import *`, this imports the `read_nb` functionality that is used in the script (currently the script is failing because it can't find `read_nb()`

Also I ran this script to add back the cleaned notebooks, as also mentioned in this [issue](https://github.com/fastai/course22/issues/47), [issue](https://github.com/fastai/course22/issues/14) and [issue](https://github.com/fastai/course22/issues/26)