### PR TITLE
Fix API call to learn.predict

### DIFF
--- a/00-is-it-a-bird-creating-a-model-from-your-own-data.ipynb
+++ b/00-is-it-a-bird-creating-a-model-from-your-own-data.ipynb
@@ -538,7 +538,7 @@
     }
    ],
    "source": [
-    "is_bird,_,probs = learn.predict(PILImage.create('bird.jpg'))\n",
+    "is_bird,_,probs = learn.predict('bird.jpg')\n",
     "print(f\"This is a: {is_bird}.\")\n",
     "print(f\"Probability it's a bird: {probs[0]:.4f}\")"
    ]


### PR DESCRIPTION
learn.predict no longer takes a PILImage as per [1]. Replace with path to the image.

[1]: https://www.kaggle.com/discussions/getting-started/389456#2155959