### PR TITLE
Update direction for turning on internet

### DIFF
--- a/00-is-it-a-bird-creating-a-model-from-your-own-data.ipynb
+++ b/00-is-it-a-bird-creating-a-model-from-your-own-data.ipynb
@@ -21,7 +21,7 @@
     "try:\n",
     "    socket.setdefaulttimeout(1)\n",
     "    socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(('1.1.1.1', 53))\n",
-    "except socket.error as ex: raise Exception(\"STOP: No internet. Click '>|' in top right and set 'Internet' switch to on\")"
+    "except socket.error as ex: raise Exception(\"STOP: No internet. Open the Notebook panel on the right and set the 'Internet' switch to on under 'Notebook Options'\")"
    ]
   },
   {


### PR DESCRIPTION
Apparently the user interface in Kaggle has changed enough that the current suggestion for enabling Internet is no longer very intuitive. I updated it to make it a bit more understandable as I got stuck on this for a while.