### PR TITLE
Update 07-how-random-forests-really-work.ipynb

### DIFF
--- a/07-how-random-forests-really-work.ipynb
+++ b/07-how-random-forests-really-work.ipynb
@@ -1243,7 +1243,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What this calculates is the probability that, if you pick two rows from a group, you'll get the same `Survived` result each time. If the group is all the same, the probability is `1.0`, and `0.0` if they're all different:"
+    "What this calculates is the Gini impurity, which measures the probability that, if you pick two rows from a group, their `Survived` results will be different. If the group is all the same, the Gini impurity is `0.0`, and `1.0` if they're all different:"
    ]
   },
   {


### PR DESCRIPTION
corrected Gini explanation as it was backwards.