### PR TITLE
Fix arm64 devcontainer build by updating container base image, install useful vscode extensions by default

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:0-3.10
+FROM mcr.microsoft.com/devcontainers/python:1.0-3.11-bookworm
 
 COPY requirements.txt /tmp/
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,5 +17,15 @@
     },
     "runArgs": [
         "--shm-size=16g"
-    ]
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-toolsai.jupyter",
+                "ms-azuretools.vscode-docker"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
When I tried to run this devcontainer on a MacBook M1 Pro, the `primp` library failed to build because compatible wheels were not available, and the build process requires Cargo (the Rust package manager) which is not installed in the container. As seen in the `primp` [README](https://github.com/deedy5/primp), Linux aarch64 wheels are only compatible with Debian >=12 whereas the devcontainer base image was using Debian 11. 

This change upgrades the base image to use Debian 12 for compatibility with existing `primp` wheels, and also upgrades to devcontainer 1.0 and Python 3.11. Also added some extensions that should be installed anyways to work with Jupyter notebooks inside the devcontainer (I think ms-toolsai.jupyter, ms-python.python and ms-azuretools.vscode-docker are required to run the notebooks, and ms-python.vscode-pylance adds code completion and other nice features).

Testing these changes: Successfully built and ran the devcontainer and the first notebook on my local machine and in GH Codespaces. I can leave another comment on this PR once I run the rest of the notebooks to ensure there are no issues.